### PR TITLE
Remove extra 'end' keyword from README and extra resource from routes.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ class CreateComments < ActiveRecord::Migration
     end
   end
 end
-end
 ```
 
 In our models, we have the following:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   resources :posts
   resources :users
-  resources :people
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
Note: I removed `resources :people` from the routes.rb file because this lesson does not require a Person model or people table.